### PR TITLE
Add env-controllable mocking for test case generation

### DIFF
--- a/mock_data.py
+++ b/mock_data.py
@@ -1,0 +1,34 @@
+MOCK_RESPONSE = '''{
+  "Scenarios": [
+    {
+      "Given": "a user is on the login page",
+      "When": "the user clicks on 'Forgot Password' and enters their registered phone number",
+      "Then": "an SMS with a reset link is sent to the user's phone"
+    },
+    {
+      "Given": "a user has received an SMS with a reset link",
+      "When": "the user clicks on the reset link within 10 minutes",
+      "Then": "the link is valid and the user is redirected to the password reset page"
+    },
+    {
+      "Given": "a user has received an SMS with a reset link",
+      "When": "the user clicks on the reset link after 10 minutes",
+      "Then": "the link is invalid and the user is shown an error message"
+    },
+    {
+      "Given": "a user is on the password reset page with a valid link",
+      "When": "the user enters a new password and confirms it",
+      "Then": "the password is successfully updated and the user is notified"
+    },
+    {
+      "Given": "a user is on the password reset page with a valid link",
+      "When": "the user enters a new password that does not meet the security criteria",
+      "Then": "the user is shown an error message indicating the password requirements"
+    },
+    {
+      "Given": "a user is on the password reset page with a valid link",
+      "When": "the user enters mismatched passwords in the new password and confirm password fields",
+      "Then": "the user is shown an error message indicating the passwords do not match"
+    }
+  ]
+}'''


### PR DESCRIPTION
## Summary
- store mock JSON response in `mock_data.py`
- load `MOCK_RESPONSE` from new module in `main.py`
- add `DEFAULT_MOCK` flag driven by `MOCK_ENABLED` env var
- use the flag as the default in `generate_test_cases` and the API route

## Testing
- `python -m py_compile main.py mock_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492566ec4c832db39637f176458d91